### PR TITLE
Save project bug

### DIFF
--- a/source/darefl/importdatawidgets/dataviewmodel.cpp
+++ b/source/darefl/importdatawidgets/dataviewmodel.cpp
@@ -19,6 +19,7 @@
 
 #include <mvvm/model/sessionitem.h>
 #include <mvvm/model/sessionmodel.h>
+#include <mvvm/viewmodel/standardchildrenstrategies.h>
 #include <mvvm/viewmodel/viewmodelcontroller.h>
 #include <mvvm/viewmodel/viewmodelutils.h>
 
@@ -43,22 +44,30 @@ QStringList deserialize(QByteArray byteArray)
     in >> result;
     return result;
 }
-
 } // namespace
 
 using namespace ModelView;
 
-DataViewModel::DataViewModel(RealDataModel* model, QObject* parent)
-    : TopItemsViewModel(model, parent)
+class DataViewModelController : public ViewModelController
 {
-    auto controller = viewModelController();
-    controller->setRowStrategy(std::make_unique<DataRowStrategy>());
+public:
+    DataViewModelController(SessionModel* session_model, ViewModelBase* view_model)
+        : ViewModelController(session_model, view_model)
+    {
+        setRowStrategy(std::make_unique<DataRowStrategy>());
+        setChildrenStrategy(std::make_unique<TopItemsStrategy>());
+    }
+};
+
+DataViewModel::DataViewModel(RealDataModel* model, QObject* parent)
+    : ViewModel(std::make_unique<DataViewModelController>(model, this), parent)
+{
 }
 
 //! Return the Qt flags depending on the provided modelindex
 Qt::ItemFlags DataViewModel::flags(const QModelIndex& index) const
 {
-    Qt::ItemFlags defaultFlags = TopItemsViewModel::flags(index);
+    Qt::ItemFlags defaultFlags = ViewModel::flags(index);
 
     if (index.isValid())
         if (dynamic_cast<RealDataModel*>(sessionModel())->dragEnabled(sessionItemFromIndex(index)))

--- a/source/darefl/importdatawidgets/dataviewmodel.h
+++ b/source/darefl/importdatawidgets/dataviewmodel.h
@@ -35,6 +35,9 @@ public:
                          const QModelIndex& parent) const override;
     bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
                       const QModelIndex& parent) override;
+
+private:
+    RealDataModel* dataModel() const;
 };
 
 #endif // DAREFL_IMPORTDATAWIDGETS_DATAVIEWMODEL_H

--- a/source/darefl/importdatawidgets/dataviewmodel.h
+++ b/source/darefl/importdatawidgets/dataviewmodel.h
@@ -21,7 +21,7 @@ class RealDataModel;
 
 //! This is the implementation of drag and drop support for the data editor
 
-class DataViewModel : public ModelView::TopItemsViewModel
+class DataViewModel : public ModelView::ViewModel
 {
     Q_OBJECT
 public:

--- a/source/darefl/layereditor/layerselectionmodel.cpp
+++ b/source/darefl/layereditor/layerselectionmodel.cpp
@@ -16,6 +16,8 @@
 LayerSelectionModel::LayerSelectionModel(ModelView::ViewModel* view_model, QObject* parent)
     : QItemSelectionModel(view_model, parent)
 {
+    // FIXME cover with unit tests after implementing ViewItemSelectionModel
+    connect(view_model, &ModelView::ViewModel::modelAboutToBeReset, [this](){clearSelection();});
 }
 
 //! Selects all rows corresponding to given items.

--- a/source/darefl/materialeditor/materialselectionmodel.cpp
+++ b/source/darefl/materialeditor/materialselectionmodel.cpp
@@ -15,6 +15,8 @@
 MaterialSelectionModel::MaterialSelectionModel(ModelView::ViewModel* view_model, QObject* parent)
     : QItemSelectionModel(view_model, parent)
 {
+    // FIXME cover with unit tests after implementing ViewItemSelectionModel
+    connect(view_model, &ModelView::ViewModel::modelAboutToBeReset, [this](){clearSelection();});
 }
 
 void MaterialSelectionModel::selectItem(ModelView::SessionItem* item)

--- a/source/darefl/model/materialpropertycontroller.cpp
+++ b/source/darefl/model/materialpropertycontroller.cpp
@@ -13,7 +13,6 @@
 #include <darefl/model/samplemodel.h>
 #include <mvvm/model/externalproperty.h>
 #include <mvvm/model/modelutils.h>
-#include <mvvm/signals/modelmapper.h>
 
 using namespace ModelView;
 

--- a/source/darefl/model/materialpropertycontroller.cpp
+++ b/source/darefl/model/materialpropertycontroller.cpp
@@ -19,30 +19,14 @@ using namespace ModelView;
 
 MaterialPropertyController::MaterialPropertyController(MaterialModel* material_model,
                                                        SampleModel* sample_model)
-    : m_material_model(material_model), m_sample_model(sample_model)
+    : ModelListener(material_model), m_sample_model(sample_model)
 {
-    connect_material_model();
+    setOnDataChange([this](auto, auto) { update_all(); });
+    setOnItemInserted([this](auto, auto) { update_all(); });
+    setOnItemRemoved([this](auto, auto) { update_all(); });
+    setOnModelReset([this](auto) { update_all(); });
+
     update_all();
-}
-
-MaterialPropertyController::~MaterialPropertyController()
-{
-    if (m_material_model)
-        m_material_model->mapper()->unsubscribe(this);
-}
-
-//! Connect with signals of MaterialModel.
-
-void MaterialPropertyController::connect_material_model()
-{
-    auto on_data_change = [this](SessionItem*, int) { update_all(); };
-    m_material_model->mapper()->setOnDataChange(on_data_change, this);
-
-    auto on_item_removed = [this](SessionItem*, TagRow) { update_all(); };
-    m_material_model->mapper()->setOnItemRemoved(on_item_removed, this);
-
-    auto on_model_destroyed = [this](SessionModel*) { m_material_model = nullptr; };
-    m_material_model->mapper()->setOnModelDestroyed(on_model_destroyed, this);
 }
 
 //! Updates all material properties in LayerItems to get new material colors and labels.
@@ -52,7 +36,7 @@ void MaterialPropertyController::update_all()
     auto layers = Utils::FindItems<LayerItem>(m_sample_model);
     for (auto layer : Utils::FindItems<LayerItem>(m_sample_model)) {
         auto property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
-        auto updated = m_material_model->material_property(property.identifier());
+        auto updated = model()->material_property(property.identifier());
         if (property != updated)
             layer->setProperty(LayerItem::P_MATERIAL, updated);
     }

--- a/source/darefl/model/materialpropertycontroller.h
+++ b/source/darefl/model/materialpropertycontroller.h
@@ -11,26 +11,22 @@
 #define DAREFL_MODEL_MATERIALPROPERTYCONTROLLER_H
 
 #include <mvvm/model/sessionmodel.h>
+#include <mvvm/signals/modellistener.h>
 
 class SampleModel;
 class MaterialModel;
 
-/*!
-@class MaterialPropertyController
-@brief Listens for all changes in material model and updates properties in SampleModel.
-*/
+//! Listens for all changes in material model and updates properties in SampleModel.
 
-class MaterialPropertyController
+class MaterialPropertyController : public ModelView::ModelListener<MaterialModel>
 {
 public:
     MaterialPropertyController(MaterialModel* material_model, SampleModel* sample_model);
-    ~MaterialPropertyController();
 
 private:
-    void connect_material_model();
     void update_all();
-    MaterialModel* m_material_model;
-    SampleModel* m_sample_model;
+
+    SampleModel* m_sample_model{nullptr};
 };
 
 #endif // DAREFL_MODEL_MATERIALPROPERTYCONTROLLER_H


### PR DESCRIPTION
The bug was appearing only when the project was changed via MaterialTable or LayerTable. When it was changed via SLD editor everything was working.

This was happening because of table cells being in selected-state after the model reload. TreeView was trying to re-select cells using persistent index machinery. Since indices were belonging to the model from the previous project, it was causing the crash. The correct behavior is to listen for onModelAboutReset and clear selection.

The second bug (possible) was in qt-mvvm itself. I was not careful enough while generating modelAboutToReset/modelReset signals in ViewModel, while underlying SessionModel was reloaded from disk.


