### PR TITLE
Simulate from imported data

### DIFF
--- a/source/darefl/importdataview/importdataview.cpp
+++ b/source/darefl/importdataview/importdataview.cpp
@@ -16,5 +16,5 @@ ImportDataView::ImportDataView(ApplicationModels* models, QWidget* parent)
     : QWidget(parent), models(models)
 {
     auto layout = new QVBoxLayout(this);
-    layout->addWidget(new ImportDataEditor(models->realDataModel()));
+    layout->addWidget(new ImportDataEditor(models->experimentalDataModel()));
 }

--- a/source/darefl/layereditor/CMakeLists.txt
+++ b/source/darefl/layereditor/CMakeLists.txt
@@ -1,6 +1,6 @@
 target_sources(${library_name} PRIVATE
-    customeditorfactory.cpp
-    customeditorfactory.h
+    customlayertreeeditorfactory.cpp
+    customlayertreeeditorfactory.h
     layereditor.cpp
     layereditor.h
     layereditoractions.cpp

--- a/source/darefl/layereditor/customeditorfactory.h
+++ b/source/darefl/layereditor/customeditorfactory.h
@@ -19,12 +19,8 @@ class CustomEditor;
 
 class ApplicationModels;
 
-/*!
-@class CustomEditorFactory
-@brief Editor factory with custom editors.
-
-Will create custom material selector for all cells containing ExternalProperty.
-*/
+//! Editor factory with custom editors.
+//! Will create custom material selector for all cells containing ExternalProperty.
 
 class CustomEditorFactory : public ModelView::DefaultEditorFactory
 {

--- a/source/darefl/layereditor/customlayertreeeditorfactory.cpp
+++ b/source/darefl/layereditor/customlayertreeeditorfactory.cpp
@@ -13,7 +13,6 @@
 #include <darefl/model/applicationmodels.h>
 #include <darefl/model/materialmodel.h>
 #include <mvvm/editors/externalpropertycomboeditor.h>
-#include <mvvm/model/customvariants.h>
 #include <mvvm/model/externalproperty.h>
 
 namespace

--- a/source/darefl/layereditor/customlayertreeeditorfactory.cpp
+++ b/source/darefl/layereditor/customlayertreeeditorfactory.cpp
@@ -9,7 +9,7 @@
 
 #include <QModelIndex>
 #include <algorithm>
-#include <darefl/layereditor/customeditorfactory.h>
+#include <darefl/layereditor/customlayertreeeditorfactory.h>
 #include <darefl/model/applicationmodels.h>
 #include <darefl/model/materialmodel.h>
 #include <mvvm/editors/externalpropertycomboeditor.h>
@@ -31,11 +31,15 @@ std::vector<ModelView::ExternalProperty> get_choice_of_materials(MaterialModel* 
 
 using namespace ModelView;
 
-CustomEditorFactory::~CustomEditorFactory() = default;
+CustomLayerTreeEditorFactory::~CustomLayerTreeEditorFactory() = default;
 
-CustomEditorFactory::CustomEditorFactory(ApplicationModels* models) : m_models(models) {}
+CustomLayerTreeEditorFactory::CustomLayerTreeEditorFactory(ApplicationModels* models)
+    : m_models(models)
+{
+}
 
-std::unique_ptr<CustomEditor> CustomEditorFactory::createEditor(const QModelIndex& index) const
+std::unique_ptr<CustomEditor>
+CustomLayerTreeEditorFactory::createEditor(const QModelIndex& index) const
 {
     auto value = index.data(Qt::EditRole);
     if (Utils::IsExtPropertyVariant(value)) {

--- a/source/darefl/layereditor/customlayertreeeditorfactory.h
+++ b/source/darefl/layereditor/customlayertreeeditorfactory.h
@@ -7,8 +7,8 @@
 //
 // ************************************************************************** //
 
-#ifndef DAREFL_LAYEREDITOR_CUSTOMEDITORFACTORY_H
-#define DAREFL_LAYEREDITOR_CUSTOMEDITORFACTORY_H
+#ifndef DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H
+#define DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H
 
 #include <mvvm/editors/defaulteditorfactory.h>
 
@@ -19,14 +19,14 @@ class CustomEditor;
 
 class ApplicationModels;
 
-//! Editor factory with custom editors.
-//! Will create custom material selector for all cells containing ExternalProperty.
+//! Custom editor factory for LayerTreeView. Substitutes default ExternalProperty editor
+//! with custom one, which will offer the choice between all defined materials.
 
-class CustomEditorFactory : public ModelView::DefaultEditorFactory
+class CustomLayerTreeEditorFactory : public ModelView::DefaultEditorFactory
 {
 public:
-    CustomEditorFactory(ApplicationModels* models);
-    ~CustomEditorFactory();
+    CustomLayerTreeEditorFactory(ApplicationModels* models);
+    ~CustomLayerTreeEditorFactory();
 
     std::unique_ptr<ModelView::CustomEditor> createEditor(const QModelIndex& index) const;
 
@@ -34,4 +34,4 @@ private:
     ApplicationModels* m_models;
 };
 
-#endif // DAREFL_LAYEREDITOR_CUSTOMEDITORFACTORY_H
+#endif // DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H

--- a/source/darefl/layereditor/layereditorwidget.cpp
+++ b/source/darefl/layereditor/layereditorwidget.cpp
@@ -8,7 +8,7 @@
 // ************************************************************************** //
 
 #include <QVBoxLayout>
-#include <darefl/layereditor/customeditorfactory.h>
+#include <darefl/layereditor/customlayertreeeditorfactory.h>
 #include <darefl/layereditor/layereditorwidget.h>
 #include <darefl/layereditor/layerselectionmodel.h>
 #include <darefl/layereditor/layertreeview.h>
@@ -39,7 +39,7 @@ void LayerEditorWidget::setModels(ApplicationModels* models)
     view_model = std::make_unique<LayerViewModel>(models->sampleModel());
     selection_model = new LayerSelectionModel(view_model.get(), this);
 
-    m_delegate->setEditorFactory(std::make_unique<CustomEditorFactory>(models));
+    m_delegate->setEditorFactory(std::make_unique<CustomLayerTreeEditorFactory>(models));
     view_model->setRootSessionItem(
         ModelView::Utils::TopItem<MultiLayerItem>(models->sampleModel()));
     layer_view->setModel(view_model.get());

--- a/source/darefl/model/CMakeLists.txt
+++ b/source/darefl/model/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${library_name} PRIVATE
     applicationmodels.cpp
     applicationmodels.h
     experimentaldata_types.h
+    experimentaldatacontroller.cpp
+    experimentaldatacontroller.h
     experimentaldataitems.cpp
     experimentaldataitems.h
     experimentaldatamodel.cpp

--- a/source/darefl/model/CMakeLists.txt
+++ b/source/darefl/model/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(${library_name} PRIVATE
     materialmodel.h
     materialpropertycontroller.cpp
     materialpropertycontroller.h
+    modelutils.cpp
+    modelutils.h
     samplemodel.cpp
     samplemodel.h
 )

--- a/source/darefl/model/applicationmodels.cpp
+++ b/source/darefl/model/applicationmodels.cpp
@@ -101,7 +101,7 @@ JobModel* ApplicationModels::jobModel()
     return p_impl->m_job_model.get();
 }
 
-ExperimentalDataModel* ApplicationModels::realDataModel()
+ExperimentalDataModel* ApplicationModels::experimentalDataModel()
 {
     return p_impl->m_realdata_model.get();
 }

--- a/source/darefl/model/applicationmodels.cpp
+++ b/source/darefl/model/applicationmodels.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include <darefl/model/applicationmodels.h>
+#include <darefl/model/experimentaldatacontroller.h>
 #include <darefl/model/experimentaldatamodel.h>
 #include <darefl/model/instrumentmodel.h>
 #include <darefl/model/jobmodel.h>
@@ -28,9 +29,10 @@ struct ApplicationModels::ApplicationModelsImpl {
     std::unique_ptr<SampleModel> m_sample_model;
     std::unique_ptr<SLDElementModel> m_sld_view_model;
     std::unique_ptr<JobModel> m_job_model;
-    std::unique_ptr<ExperimentalDataModel> m_realdata_model;
+    std::unique_ptr<ExperimentalDataModel> m_experimental_model;
     std::unique_ptr<InstrumentModel> m_instrument_model;
-    std::unique_ptr<MaterialPropertyController> m_property_controller;
+    std::unique_ptr<MaterialPropertyController> m_material_controller;
+    std::unique_ptr<ExperimentalDataController> m_data_controller;
     std::shared_ptr<ItemPool> item_pool;
 
     ApplicationModelsImpl()
@@ -40,10 +42,12 @@ struct ApplicationModels::ApplicationModelsImpl {
         m_sample_model = std::make_unique<SampleModel>(item_pool);
         m_sld_view_model = std::make_unique<SLDElementModel>();
         m_job_model = std::make_unique<JobModel>();
-        m_realdata_model = std::make_unique<ExperimentalDataModel>(item_pool);
+        m_experimental_model = std::make_unique<ExperimentalDataModel>(item_pool);
         m_instrument_model = std::make_unique<InstrumentModel>(item_pool);
-        m_property_controller = std::make_unique<MaterialPropertyController>(m_material_model.get(),
+        m_material_controller = std::make_unique<MaterialPropertyController>(m_material_model.get(),
                                                                              m_sample_model.get());
+        m_data_controller = std::make_unique<ExperimentalDataController>(m_experimental_model.get(),
+                                                                         m_instrument_model.get());
         m_sample_model->create_default_multilayer();
         update_material_properties();
     }
@@ -73,7 +77,7 @@ struct ApplicationModels::ApplicationModelsImpl {
     std::vector<SessionModel*> application_models() const
     {
         return {m_material_model.get(), m_sample_model.get(), m_instrument_model.get(),
-                m_sld_view_model.get(), m_job_model.get(),    m_realdata_model.get()};
+                m_sld_view_model.get(), m_job_model.get(),    m_experimental_model.get()};
     }
 };
 
@@ -103,7 +107,7 @@ JobModel* ApplicationModels::jobModel()
 
 ExperimentalDataModel* ApplicationModels::experimentalDataModel()
 {
-    return p_impl->m_realdata_model.get();
+    return p_impl->m_experimental_model.get();
 }
 
 InstrumentModel* ApplicationModels::instrumentModel()

--- a/source/darefl/model/applicationmodels.cpp
+++ b/source/darefl/model/applicationmodels.cpp
@@ -40,7 +40,7 @@ struct ApplicationModels::ApplicationModelsImpl {
         m_sample_model = std::make_unique<SampleModel>(item_pool);
         m_sld_view_model = std::make_unique<SLDElementModel>();
         m_job_model = std::make_unique<JobModel>();
-        m_realdata_model = std::make_unique<ExperimentalDataModel>();
+        m_realdata_model = std::make_unique<ExperimentalDataModel>(item_pool);
         m_instrument_model = std::make_unique<InstrumentModel>();
         m_property_controller = std::make_unique<MaterialPropertyController>(m_material_model.get(),
                                                                              m_sample_model.get());

--- a/source/darefl/model/applicationmodels.cpp
+++ b/source/darefl/model/applicationmodels.cpp
@@ -41,7 +41,7 @@ struct ApplicationModels::ApplicationModelsImpl {
         m_sld_view_model = std::make_unique<SLDElementModel>();
         m_job_model = std::make_unique<JobModel>();
         m_realdata_model = std::make_unique<ExperimentalDataModel>(item_pool);
-        m_instrument_model = std::make_unique<InstrumentModel>();
+        m_instrument_model = std::make_unique<InstrumentModel>(item_pool);
         m_property_controller = std::make_unique<MaterialPropertyController>(m_material_model.get(),
                                                                              m_sample_model.get());
         m_sample_model->create_default_multilayer();

--- a/source/darefl/model/applicationmodels.h
+++ b/source/darefl/model/applicationmodels.h
@@ -38,7 +38,7 @@ public:
     SampleModel* sampleModel();
     SLDElementModel* sldViewModel();
     JobModel* jobModel();
-    ExperimentalDataModel* realDataModel();
+    ExperimentalDataModel* experimentalDataModel();
     InstrumentModel* instrumentModel();
 
     std::vector<ModelView::SessionModel*> persistent_models() const override;

--- a/source/darefl/model/experimentaldatacontroller.cpp
+++ b/source/darefl/model/experimentaldatacontroller.cpp
@@ -1,0 +1,43 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include <darefl/model/experimentaldatacontroller.h>
+#include <darefl/model/experimentaldataitems.h>
+#include <darefl/model/experimentaldatamodel.h>
+#include <darefl/model/instrumentitems.h>
+#include <darefl/model/instrumentmodel.h>
+#include <darefl/model/modelutils.h>
+#include <mvvm/model/externalproperty.h>
+#include <mvvm/model/modelutils.h>
+
+ExperimentalDataController::ExperimentalDataController(ExperimentalDataModel* data_model,
+                                                       InstrumentModel* instrument_model)
+    : ModelListener(data_model), m_instrument_model(instrument_model)
+{
+    setOnDataChange([this](auto, auto) { update_all(); });
+    setOnItemInserted([this](auto, auto) { update_all(); });
+    setOnItemRemoved([this](auto, auto) { update_all(); });
+    setOnModelReset([this](auto) { update_all(); });
+
+    update_all();
+}
+
+//! Updates all material properties in LayerItems to get new material colors and labels.
+
+void ExperimentalDataController::update_all()
+{
+    for (auto scan : ModelView::Utils::FindItems<ExperimentalScanItem>(m_instrument_model)) {
+        auto property =
+            scan->property<ModelView::ExternalProperty>(ExperimentalScanItem::P_IMPORTED_DATA);
+        auto updated =
+            Utils::FindProperty(Utils::CreateGraphProperties(model()), property.identifier());
+        if (property != updated)
+            scan->setProperty(ExperimentalScanItem::P_IMPORTED_DATA, updated);
+    }
+}

--- a/source/darefl/model/experimentaldatacontroller.h
+++ b/source/darefl/model/experimentaldatacontroller.h
@@ -1,0 +1,34 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef DAREFL_MODEL_EXPERIMENTALDATACONTROLLER_H
+#define DAREFL_MODEL_EXPERIMENTALDATACONTROLLER_H
+
+#include <mvvm/model/sessionmodel.h>
+#include <mvvm/signals/modellistener.h>
+
+class InstrumentModel;
+class ExperimentalDataModel;
+
+//! Listens for all changes in ExperimentalDataModel and updates properties in InstrumentModel.
+//! Main task is to update links of ExperimentalScanItem to particular imported graph, when
+//! ExperimentalDataModel is changing.
+
+class ExperimentalDataController : public ModelView::ModelListener<ExperimentalDataModel>
+{
+public:
+    ExperimentalDataController(ExperimentalDataModel* data_model, InstrumentModel* instrument_model);
+
+private:
+    void update_all();
+
+    InstrumentModel* m_instrument_model{nullptr};
+};
+
+#endif // DAREFL_MODEL_EXPERIMENTALDATACONTROLLER_H

--- a/source/darefl/model/experimentaldatamodel.cpp
+++ b/source/darefl/model/experimentaldatamodel.cpp
@@ -121,7 +121,7 @@ void ExperimentalDataModel::addDataToGroup(CanvasItem* data_group, RealDataStruc
     std::vector<double> axis_vec;
     std::vector<double> data_vec;
 
-    for (int i = 0; i < data_struct.data.size(); ++i) {
+    for (size_t i = 0; i < data_struct.data.size(); ++i) {
         if (!std::isnan(data_struct.axis.at(i)) && !std::isnan(data_struct.data.at(i))) {
             axis_vec.push_back(data_struct.axis.at(i));
             data_vec.push_back(data_struct.data.at(i));

--- a/source/darefl/model/experimentaldatamodel.cpp
+++ b/source/darefl/model/experimentaldatamodel.cpp
@@ -27,6 +27,8 @@ using namespace ModelView;
 namespace
 {
 
+const std::string model_name{"ExperimentalDataModel"};
+
 std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 {
     auto result = std::make_unique<ModelView::ItemCatalogue>();
@@ -37,14 +39,16 @@ std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 
 } // namespace
 
-ExperimentalDataModel::ExperimentalDataModel() : SessionModel("ExperimentalDataModel")
+ExperimentalDataModel::ExperimentalDataModel() : SessionModel(model_name)
 {
-    setItemCatalogue(CreateItemCatalogue());
+    init_model();
+}
 
-    insertItem<ExperimentalDataContainerItem>(rootItem());
-    insertItem<CanvasContainerItem>(rootItem());
+ExperimentalDataModel::ExperimentalDataModel(std::shared_ptr<ItemPool> pool)
+    : SessionModel(model_name, pool)
 
-    setUndoRedoEnabled(true);
+{
+    init_model();
 }
 
 //! Returns the data container of the model.
@@ -245,4 +249,14 @@ bool ExperimentalDataModel::mergeItems(std::vector<ModelView::SessionItem*> item
 CanvasContainerItem* ExperimentalDataModel::canvasContainer() const
 {
     return topItem<CanvasContainerItem>();
+}
+
+void ExperimentalDataModel::init_model()
+{
+    setItemCatalogue(CreateItemCatalogue());
+
+    insertItem<ExperimentalDataContainerItem>(rootItem());
+    insertItem<CanvasContainerItem>(rootItem());
+
+    setUndoRedoEnabled(true);
 }

--- a/source/darefl/model/experimentaldatamodel.h
+++ b/source/darefl/model/experimentaldatamodel.h
@@ -31,7 +31,9 @@ class ExperimentalDataModel : public ModelView::SessionModel
 {
 public:
     using name_identifier_t = std::pair<std::string, std::string>;
+
     ExperimentalDataModel();
+    ExperimentalDataModel(std::shared_ptr<ModelView::ItemPool> pool);
 
     CanvasItem* addDataToCollection(RealDataStruct data_struct, CanvasContainerItem* data_node,
                                     CanvasItem* data_group = nullptr);
@@ -55,6 +57,8 @@ private:
 
     void addDataToGroup(CanvasItem* data_group, RealDataStruct& data_struct);
     void removeDataFromGroup(ModelView::GraphItem* item);
+
+    void init_model();
 };
 
 #endif // DAREFL_MODEL_EXPERIMENTALDATAMODEL_H

--- a/source/darefl/model/instrumentitems.cpp
+++ b/source/darefl/model/instrumentitems.cpp
@@ -10,8 +10,11 @@
 #include <QColor>
 #include <darefl/model/instrumentitems.h>
 #include <darefl/model/item_constants.h>
+#include <darefl/model/modelutils.h>
 #include <mvvm/model/externalproperty.h>
+#include <mvvm/model/sessionmodel.h>
 #include <mvvm/standarditems/axisitems.h>
+#include <mvvm/standarditems/graphitem.h>
 
 using namespace ModelView;
 
@@ -42,13 +45,26 @@ std::vector<double> QSpecScanItem::qScanValues() const
 ExperimentalScanItem::ExperimentalScanItem()
     : BasicSpecularScanItem(::Constants::ExperimentalScanItemType)
 {
-    addProperty(P_IMPORTED_DATA, ExternalProperty("Undefined", QColor(Qt::red)))
-        ->setDisplayName("Graph");
+    addProperty(P_IMPORTED_DATA, ExternalProperty::undefined())->setDisplayName("Graph");
+}
+
+void ExperimentalScanItem::setGraphItem(GraphItem* graph)
+{
+    setProperty(P_IMPORTED_DATA, ::Utils::CreateProperty(graph));
+}
+
+GraphItem* ExperimentalScanItem::graphItem() const
+{
+    if (model()) {
+        auto graph_id = property<ExternalProperty>(P_IMPORTED_DATA).identifier();
+        return dynamic_cast<GraphItem*>(model()->findItem(graph_id));
+    }
+    return nullptr;
 }
 
 std::vector<double> ExperimentalScanItem::qScanValues() const
 {
-    return {};
+    return graphItem() ? graphItem()->binCenters() : std::vector<double>();
 }
 
 // ----------------------------------------------------------------------------

--- a/source/darefl/model/instrumentitems.cpp
+++ b/source/darefl/model/instrumentitems.cpp
@@ -7,28 +7,40 @@
 //
 // ************************************************************************** //
 
+#include <QColor>
 #include <darefl/model/instrumentitems.h>
 #include <darefl/model/item_constants.h>
+#include <mvvm/model/externalproperty.h>
 
-QSpecScanItem::QSpecScanItem() : ModelView::FixedBinAxisItem(::Constants::QSpecScanItemType)
+using namespace ModelView;
+
+QSpecScanItem::QSpecScanItem() : FixedBinAxisItem(::Constants::QSpecScanItemType)
 {
-    setProperty(ModelView::FixedBinAxisItem::P_NBINS, 500);
-    setProperty(ModelView::FixedBinAxisItem::P_MIN, 0.0);
-    setProperty(ModelView::FixedBinAxisItem::P_MAX, 1.0);
+    setProperty(FixedBinAxisItem::P_NBINS, 500);
+    setProperty(FixedBinAxisItem::P_MIN, 0.0);
+    setProperty(FixedBinAxisItem::P_MAX, 1.0);
 }
 
 // ----------------------------------------------------------------------------
 
-SpecularScanGroupItem::SpecularScanGroupItem()
-    : ModelView::GroupItem(::Constants::SpecularScanGroupItemType)
+ExperimentalScanItem::ExperimentalScanItem() : CompoundItem(::Constants::ExperimentalScanItemType)
+{
+    addProperty(P_IMPORTED_DATA, ExternalProperty("Undefined", QColor(Qt::red)))
+        ->setDisplayName("Graph");
+}
+
+// ----------------------------------------------------------------------------
+
+SpecularScanGroupItem::SpecularScanGroupItem() : GroupItem(::Constants::SpecularScanGroupItemType)
 {
     registerItem<QSpecScanItem>("Q-scan", /*make_selected*/ true);
+    registerItem<ExperimentalScanItem>("Based on data");
     init_group();
 }
 
 // ----------------------------------------------------------------------------
 
-SpecularBeamItem::SpecularBeamItem() : ModelView::CompoundItem(::Constants::SpecularBeamItemType)
+SpecularBeamItem::SpecularBeamItem() : CompoundItem(::Constants::SpecularBeamItemType)
 {
     addProperty(P_INTENSITY, 1.0)->setDisplayName("Intensity");
     addProperty<SpecularScanGroupItem>(P_SCAN_GROUP)->setDisplayName("Specular scan type");
@@ -46,7 +58,7 @@ std::vector<double> SpecularBeamItem::qScanValues() const
 // ----------------------------------------------------------------------------
 
 SpecularInstrumentItem::SpecularInstrumentItem()
-    : ModelView::CompoundItem(::Constants::SpecularInstrumentItemType)
+    : CompoundItem(::Constants::SpecularInstrumentItemType)
 {
     addProperty<SpecularBeamItem>(P_BEAM);
 }

--- a/source/darefl/model/instrumentitems.cpp
+++ b/source/darefl/model/instrumentitems.cpp
@@ -20,18 +20,13 @@ BasicSpecularScanItem::BasicSpecularScanItem(const std::string& model_type)
 {
 }
 
-std::vector<double> BasicSpecularScanItem::qScanValues() const
-{
-    return {};
-}
-
 // ----------------------------------------------------------------------------
 
 QSpecScanItem::QSpecScanItem() : BasicSpecularScanItem(::Constants::QSpecScanItemType)
 {
-    addProperty(P_NBINS, 500);
-    addProperty(P_QMIN, 0.0);
-    addProperty(P_QMAX, 1.0);
+    addProperty(P_NBINS, 500)->setDisplayName("Nbins");
+    addProperty(P_QMIN, 0.0)->setDisplayName("Qmin");
+    addProperty(P_QMAX, 1.0)->setDisplayName("Qmax");
 }
 
 std::vector<double> QSpecScanItem::qScanValues() const
@@ -49,6 +44,11 @@ ExperimentalScanItem::ExperimentalScanItem()
 {
     addProperty(P_IMPORTED_DATA, ExternalProperty("Undefined", QColor(Qt::red)))
         ->setDisplayName("Graph");
+}
+
+std::vector<double> ExperimentalScanItem::qScanValues() const
+{
+    return {};
 }
 
 // ----------------------------------------------------------------------------

--- a/source/darefl/model/instrumentitems.h
+++ b/source/darefl/model/instrumentitems.h
@@ -22,8 +22,17 @@
 class QSpecScanItem : public ModelView::FixedBinAxisItem
 {
 public:
-    static inline const std::string P_QMIN = "P_BEAM";
+    static inline const std::string P_QMIN = "P_QMIN";
     QSpecScanItem();
+};
+
+//! Represents scan according to imported experimental data.
+
+class ExperimentalScanItem : public ModelView::CompoundItem
+{
+public:
+    static inline const std::string P_IMPORTED_DATA = "P_IMPORTED_DATA";
+    ExperimentalScanItem();
 };
 
 //! Represent selection of possible specular scans.

--- a/source/darefl/model/instrumentitems.h
+++ b/source/darefl/model/instrumentitems.h
@@ -22,7 +22,7 @@ class BasicSpecularScanItem : public ModelView::CompoundItem
 {
 public:
     BasicSpecularScanItem(const std::string& model_type);
-    virtual std::vector<double> qScanValues() const;
+    virtual std::vector<double> qScanValues() const = 0;
 };
 
 //! Represents Q-space specular scan with fixed bin size.
@@ -35,7 +35,7 @@ public:
     static inline const std::string P_QMAX = "P_QMAX";
     QSpecScanItem();
 
-    virtual std::vector<double> qScanValues() const;
+    virtual std::vector<double> qScanValues() const override;
 };
 
 //! Represents scan according to imported experimental data.
@@ -45,6 +45,8 @@ class ExperimentalScanItem : public BasicSpecularScanItem
 public:
     static inline const std::string P_IMPORTED_DATA = "P_IMPORTED_DATA";
     ExperimentalScanItem();
+
+    virtual std::vector<double> qScanValues() const override;
 };
 
 //! Represent selection of possible specular scans.

--- a/source/darefl/model/instrumentitems.h
+++ b/source/darefl/model/instrumentitems.h
@@ -15,20 +15,32 @@
 
 #include <mvvm/model/compounditem.h>
 #include <mvvm/model/groupitem.h>
-#include <mvvm/standarditems/axisitems.h>
 
-//! Represents Q-space specular scan.
+//! Represents base type for beam scan parameters.
 
-class QSpecScanItem : public ModelView::FixedBinAxisItem
+class BasicSpecularScanItem : public ModelView::CompoundItem
 {
 public:
+    BasicSpecularScanItem(const std::string& model_type);
+    virtual std::vector<double> qScanValues() const;
+};
+
+//! Represents Q-space specular scan with fixed bin size.
+
+class QSpecScanItem : public BasicSpecularScanItem
+{
+public:
+    static inline const std::string P_NBINS = "P_NBINS";
     static inline const std::string P_QMIN = "P_QMIN";
+    static inline const std::string P_QMAX = "P_QMAX";
     QSpecScanItem();
+
+    virtual std::vector<double> qScanValues() const;
 };
 
 //! Represents scan according to imported experimental data.
 
-class ExperimentalScanItem : public ModelView::CompoundItem
+class ExperimentalScanItem : public BasicSpecularScanItem
 {
 public:
     static inline const std::string P_IMPORTED_DATA = "P_IMPORTED_DATA";

--- a/source/darefl/model/instrumentitems.h
+++ b/source/darefl/model/instrumentitems.h
@@ -16,6 +16,10 @@
 #include <mvvm/model/compounditem.h>
 #include <mvvm/model/groupitem.h>
 
+namespace ModelView {
+class GraphItem;
+}
+
 //! Represents base type for beam scan parameters.
 
 class BasicSpecularScanItem : public ModelView::CompoundItem
@@ -35,7 +39,7 @@ public:
     static inline const std::string P_QMAX = "P_QMAX";
     QSpecScanItem();
 
-    virtual std::vector<double> qScanValues() const override;
+    std::vector<double> qScanValues() const override;
 };
 
 //! Represents scan according to imported experimental data.
@@ -46,7 +50,11 @@ public:
     static inline const std::string P_IMPORTED_DATA = "P_IMPORTED_DATA";
     ExperimentalScanItem();
 
-    virtual std::vector<double> qScanValues() const override;
+    void setGraphItem(ModelView::GraphItem* graph);
+
+    ModelView::GraphItem* graphItem() const;
+
+    std::vector<double> qScanValues() const override;
 };
 
 //! Represent selection of possible specular scans.

--- a/source/darefl/model/instrumentmodel.cpp
+++ b/source/darefl/model/instrumentmodel.cpp
@@ -23,6 +23,7 @@ std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
     result->registerItem<SpecularBeamItem>();
     result->registerItem<SpecularScanGroupItem>();
     result->registerItem<QSpecScanItem>();
+    result->registerItem<ExperimentalScanItem>();
     return result;
 }
 

--- a/source/darefl/model/instrumentmodel.cpp
+++ b/source/darefl/model/instrumentmodel.cpp
@@ -16,6 +16,8 @@ using namespace ModelView;
 namespace
 {
 
+const std::string model_name = "InstrumentModel";
+
 std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 {
     auto result = std::make_unique<ModelView::ItemCatalogue>();
@@ -31,7 +33,17 @@ std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 
 InstrumentModel::InstrumentModel() : ModelView::SessionModel("InstrumentModel")
 {
-    setItemCatalogue(CreateItemCatalogue());
+    init_model();
+}
 
+InstrumentModel::InstrumentModel(std::shared_ptr<ItemPool> pool)
+    : ModelView::SessionModel(model_name, pool)
+{
+    init_model();
+}
+
+void InstrumentModel::init_model()
+{
+    setItemCatalogue(CreateItemCatalogue());
     insertItem<SpecularInstrumentItem>();
 }

--- a/source/darefl/model/instrumentmodel.h
+++ b/source/darefl/model/instrumentmodel.h
@@ -18,6 +18,10 @@ class InstrumentModel : public ModelView::SessionModel
 {
 public:
     InstrumentModel();
+    InstrumentModel(std::shared_ptr<ModelView::ItemPool> pool);
+
+private:
+    void init_model();
 };
 
 #endif // DAREFL_MODEL_INSTRUMENTMODEL_H

--- a/source/darefl/model/item_constants.h
+++ b/source/darefl/model/item_constants.h
@@ -29,6 +29,7 @@ const std::string SpecularInstrumentItemType = "SpecularInstrument";
 const std::string SpecularBeamItemType = "SpecularBeam";
 const std::string SpecularScanGroupItemType = "SpecularScanGroup";
 const std::string QSpecScanItemType = "QSpecScan";
+const std::string ExperimentalScanItemType = "ExperimentalScan";
 
 } // namespace Constants
 

--- a/source/darefl/model/materialmodel.cpp
+++ b/source/darefl/model/materialmodel.cpp
@@ -103,9 +103,8 @@ std::vector<ExternalProperty> MaterialModel::material_data(std::string container
 
 //! Returns property from given material id.
 
-ExternalProperty MaterialModel::material_property(const std::string& id, std::string container_id)
+ExternalProperty MaterialModel::material_property(const std::string& id)
 {
-    auto materials = material_data(container_id);
     for (const auto& prop : material_data())
         if (prop.identifier() == id)
             return prop;

--- a/source/darefl/model/materialmodel.h
+++ b/source/darefl/model/materialmodel.h
@@ -39,8 +39,7 @@ public:
     std::vector<ModelView::ExternalProperty>
     material_data(std::string container_id = std::string()) const;
 
-    ModelView::ExternalProperty material_property(const std::string& id,
-                                                  std::string container_id = std::string());
+    ModelView::ExternalProperty material_property(const std::string& id);
 
     MaterialBaseItem* cloneMaterial(const MaterialBaseItem* item);
 

--- a/source/darefl/model/materialmodel.h
+++ b/source/darefl/model/materialmodel.h
@@ -23,10 +23,7 @@ class MaterialBaseItem;
 class MaterialContainerItem;
 class SLDMaterialItem;
 
-/*!
-@class MaterialModel
-@brief Model to hold MaterialItems.
-*/
+//! Model to hold MaterialItems.
 
 class MaterialModel : public ModelView::SessionModel
 {

--- a/source/darefl/model/materialpropertycontroller.cpp
+++ b/source/darefl/model/materialpropertycontroller.cpp
@@ -32,7 +32,6 @@ MaterialPropertyController::MaterialPropertyController(MaterialModel* material_m
 
 void MaterialPropertyController::update_all()
 {
-    auto layers = Utils::FindItems<LayerItem>(m_sample_model);
     for (auto layer : Utils::FindItems<LayerItem>(m_sample_model)) {
         auto property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
         auto updated = model()->material_property(property.identifier());

--- a/source/darefl/model/modelutils.cpp
+++ b/source/darefl/model/modelutils.cpp
@@ -1,0 +1,19 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include <darefl/model/modelutils.h>
+#include <mvvm/model/externalproperty.h>
+#include <mvvm/standarditems/graphitem.h>
+
+ModelView::ExternalProperty Utils::CreateProperty(const ModelView::GraphItem* graph)
+{
+    std::string name = graph->parent()->displayName() + "/" + graph->displayName();
+    auto color = graph->property<QColor>(ModelView::GraphItem::P_COLOR);
+    return ModelView::ExternalProperty(name, color, graph->identifier());
+}

--- a/source/darefl/model/modelutils.cpp
+++ b/source/darefl/model/modelutils.cpp
@@ -27,3 +27,15 @@ std::vector<ModelView::ExternalProperty> Utils::CreateGraphProperties(Experiment
         result.push_back(::Utils::CreateProperty(graph));
     return result;
 }
+
+// FIXME unit tests
+ModelView::ExternalProperty
+Utils::FindProperty(const std::vector<ModelView::ExternalProperty>& properties,
+                    const std::string& id)
+{
+    for (const auto& prop : properties)
+        if (prop.identifier() == id)
+            return prop;
+
+    return ModelView::ExternalProperty::undefined();
+}

--- a/source/darefl/model/modelutils.cpp
+++ b/source/darefl/model/modelutils.cpp
@@ -7,8 +7,10 @@
 //
 // ************************************************************************** //
 
+#include <darefl/model/experimentaldatamodel.h>
 #include <darefl/model/modelutils.h>
 #include <mvvm/model/externalproperty.h>
+#include <mvvm/model/modelutils.h>
 #include <mvvm/standarditems/graphitem.h>
 
 ModelView::ExternalProperty Utils::CreateProperty(const ModelView::GraphItem* graph)
@@ -16,4 +18,12 @@ ModelView::ExternalProperty Utils::CreateProperty(const ModelView::GraphItem* gr
     std::string name = graph->parent()->displayName() + "/" + graph->displayName();
     auto color = graph->property<QColor>(ModelView::GraphItem::P_COLOR);
     return ModelView::ExternalProperty(name, color, graph->identifier());
+}
+
+std::vector<ModelView::ExternalProperty> Utils::CreateGraphProperties(ExperimentalDataModel* model)
+{
+    std::vector<ModelView::ExternalProperty> result;
+    for (auto graph : ModelView::Utils::FindItems<ModelView::GraphItem>(model))
+        result.push_back(::Utils::CreateProperty(graph));
+    return result;
 }

--- a/source/darefl/model/modelutils.h
+++ b/source/darefl/model/modelutils.h
@@ -11,6 +11,7 @@
 #define DAREFL_MODEL_MODELUTILS_H
 
 #include <vector>
+#include <string>
 
 namespace ModelView
 {
@@ -25,12 +26,14 @@ namespace Utils
 
 //! Returns property representing given graph.
 //! Used to link with the graph from various editors.
-
 ModelView::ExternalProperty CreateProperty(const ModelView::GraphItem* graph);
 
 //! Returns vector of properties representing GraphItem content of the model.
-
 std::vector<ModelView::ExternalProperty> CreateGraphProperties(ExperimentalDataModel* model);
+
+//! Finds the property with the same `id` in given vector and returns it.
+ModelView::ExternalProperty FindProperty(const std::vector<ModelView::ExternalProperty>& properties,
+                                         const std::string& id);
 
 } // namespace Utils
 

--- a/source/darefl/model/modelutils.h
+++ b/source/darefl/model/modelutils.h
@@ -10,11 +10,15 @@
 #ifndef DAREFL_MODEL_MODELUTILS_H
 #define DAREFL_MODEL_MODELUTILS_H
 
+#include <vector>
+
 namespace ModelView
 {
 class GraphItem;
 class ExternalProperty;
 } // namespace ModelView
+
+class ExperimentalDataModel;
 
 namespace Utils
 {
@@ -23,6 +27,10 @@ namespace Utils
 //! Used to link with the graph from various editors.
 
 ModelView::ExternalProperty CreateProperty(const ModelView::GraphItem* graph);
+
+//! Returns vector of properties representing GraphItem content of the model.
+
+std::vector<ModelView::ExternalProperty> CreateGraphProperties(ExperimentalDataModel* model);
 
 } // namespace Utils
 

--- a/source/darefl/model/modelutils.h
+++ b/source/darefl/model/modelutils.h
@@ -1,0 +1,29 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef DAREFL_MODEL_MODELUTILS_H
+#define DAREFL_MODEL_MODELUTILS_H
+
+namespace ModelView
+{
+class GraphItem;
+class ExternalProperty;
+} // namespace ModelView
+
+namespace Utils
+{
+
+//! Returns property representing given graph.
+//! Used to link with the graph from various editors.
+
+ModelView::ExternalProperty CreateProperty(const ModelView::GraphItem* graph);
+
+} // namespace Utils
+
+#endif // DAREFL_MODEL_MODELUTILS_H

--- a/source/darefl/quicksimeditor/CMakeLists.txt
+++ b/source/darefl/quicksimeditor/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(${library_name} PRIVATE
+    custombeampropertyeditorfactory.cpp
+    custombeampropertyeditorfactory.h
     jobmanager.cpp
     jobmanager.h
     materialprofile.cpp

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -31,9 +31,8 @@ namespace
 std::vector<ModelView::ExternalProperty> available_graph_properties(ExperimentalDataModel* model)
 {
     std::vector<ModelView::ExternalProperty> result{ExternalProperty::undefined()};
-
-    for (auto graph : ModelView::Utils::FindItems<GraphItem>(model))
-        result.push_back(::Utils::CreateProperty(graph));
+    auto properties = ::Utils::CreateGraphProperties(model);
+    std::copy(properties.begin(), properties.end(), std::back_inserter(result));
     return result;
 }
 } // namespace

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -1,0 +1,60 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include <QModelIndex>
+#include <algorithm>
+#include <darefl/model/applicationmodels.h>
+#include <darefl/model/experimentaldataitems.h>
+#include <darefl/model/experimentaldatamodel.h>
+#include <darefl/model/materialmodel.h>
+#include <darefl/quicksimeditor/custombeampropertyeditorfactory.h>
+#include <mvvm/editors/externalpropertycomboeditor.h>
+#include <mvvm/model/externalproperty.h>
+#include <mvvm/model/modelutils.h>
+#include <mvvm/standarditems/graphitem.h>
+
+using namespace ModelView;
+
+namespace
+{
+
+//! Returns vector of ExternalProperty representing imported graphs.
+//! Use "Undefined graph" as a first item in a list.
+
+std::vector<ModelView::ExternalProperty> get_choice_of_graphs(ExperimentalDataModel* model)
+{
+    std::vector<ModelView::ExternalProperty> result{ExternalProperty("Undefined", QColor(Qt::red))};
+
+    for (auto graph : Utils::FindItems<GraphItem>(model)) {
+        std::string name = graph->parent()->displayName() + "/" + graph->displayName();
+        auto color = graph->property<QColor>(GraphItem::P_COLOR);
+        result.push_back(ExternalProperty(name, color, graph->identifier()));
+    }
+    return result;
+}
+} // namespace
+
+CustomBeamPropertyEditorFactory::~CustomBeamPropertyEditorFactory() = default;
+
+CustomBeamPropertyEditorFactory::CustomBeamPropertyEditorFactory(ApplicationModels* models)
+    : m_models(models)
+{
+}
+
+std::unique_ptr<CustomEditor>
+CustomBeamPropertyEditorFactory::createEditor(const QModelIndex& index) const
+{
+    auto value = index.data(Qt::EditRole);
+    if (Utils::IsExtPropertyVariant(value)) {
+        auto choice_callback = [this]() { return get_choice_of_graphs(m_models->realDataModel()); };
+        return std::make_unique<ExternalPropertyComboEditor>(choice_callback);
+    } else {
+        return DefaultEditorFactory::createEditor(index);
+    }
+}

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -51,7 +51,7 @@ CustomBeamPropertyEditorFactory::createEditor(const QModelIndex& index) const
     auto value = index.data(Qt::EditRole);
     if (ModelView::Utils::IsExtPropertyVariant(value)) {
         auto choice_callback = [this]() {
-            return available_graph_properties(m_models->realDataModel());
+            return available_graph_properties(m_models->experimentalDataModel());
         };
         return std::make_unique<ExternalPropertyComboEditor>(choice_callback);
     } else {

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -13,6 +13,7 @@
 #include <darefl/model/experimentaldataitems.h>
 #include <darefl/model/experimentaldatamodel.h>
 #include <darefl/model/materialmodel.h>
+#include <darefl/model/modelutils.h>
 #include <darefl/quicksimeditor/custombeampropertyeditorfactory.h>
 #include <mvvm/editors/externalpropertycomboeditor.h>
 #include <mvvm/model/externalproperty.h>
@@ -31,11 +32,8 @@ std::vector<ModelView::ExternalProperty> get_choice_of_graphs(ExperimentalDataMo
 {
     std::vector<ModelView::ExternalProperty> result{ExternalProperty::undefined()};
 
-    for (auto graph : Utils::FindItems<GraphItem>(model)) {
-        std::string name = graph->parent()->displayName() + "/" + graph->displayName();
-        auto color = graph->property<QColor>(GraphItem::P_COLOR);
-        result.push_back(ExternalProperty(name, color, graph->identifier()));
-    }
+    for (auto graph : ModelView::Utils::FindItems<GraphItem>(model))
+        result.push_back(::Utils::CreateProperty(graph));
     return result;
 }
 } // namespace
@@ -51,7 +49,7 @@ std::unique_ptr<CustomEditor>
 CustomBeamPropertyEditorFactory::createEditor(const QModelIndex& index) const
 {
     auto value = index.data(Qt::EditRole);
-    if (Utils::IsExtPropertyVariant(value)) {
+    if (ModelView::Utils::IsExtPropertyVariant(value)) {
         auto choice_callback = [this]() { return get_choice_of_graphs(m_models->realDataModel()); };
         return std::make_unique<ExternalPropertyComboEditor>(choice_callback);
     } else {

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -28,7 +28,7 @@ namespace
 //! Returns vector of ExternalProperty representing imported graphs.
 //! Use "Undefined graph" as a first item in a list.
 
-std::vector<ModelView::ExternalProperty> get_choice_of_graphs(ExperimentalDataModel* model)
+std::vector<ModelView::ExternalProperty> available_graph_properties(ExperimentalDataModel* model)
 {
     std::vector<ModelView::ExternalProperty> result{ExternalProperty::undefined()};
 
@@ -50,7 +50,9 @@ CustomBeamPropertyEditorFactory::createEditor(const QModelIndex& index) const
 {
     auto value = index.data(Qt::EditRole);
     if (ModelView::Utils::IsExtPropertyVariant(value)) {
-        auto choice_callback = [this]() { return get_choice_of_graphs(m_models->realDataModel()); };
+        auto choice_callback = [this]() {
+            return available_graph_properties(m_models->realDataModel());
+        };
         return std::make_unique<ExternalPropertyComboEditor>(choice_callback);
     } else {
         return DefaultEditorFactory::createEditor(index);

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.cpp
@@ -29,7 +29,7 @@ namespace
 
 std::vector<ModelView::ExternalProperty> get_choice_of_graphs(ExperimentalDataModel* model)
 {
-    std::vector<ModelView::ExternalProperty> result{ExternalProperty("Undefined", QColor(Qt::red))};
+    std::vector<ModelView::ExternalProperty> result{ExternalProperty::undefined()};
 
     for (auto graph : Utils::FindItems<GraphItem>(model)) {
         std::string name = graph->parent()->displayName() + "/" + graph->displayName();

--- a/source/darefl/quicksimeditor/custombeampropertyeditorfactory.h
+++ b/source/darefl/quicksimeditor/custombeampropertyeditorfactory.h
@@ -7,8 +7,8 @@
 //
 // ************************************************************************** //
 
-#ifndef DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H
-#define DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H
+#ifndef DAREFL_QUICKSIMEDITOR_CUSTOMBEAMPROPERTYEDITORFACTORY_H
+#define DAREFL_QUICKSIMEDITOR_CUSTOMBEAMPROPERTYEDITORFACTORY_H
 
 #include <mvvm/editors/defaulteditorfactory.h>
 
@@ -17,11 +17,11 @@ class ApplicationModels;
 //! Custom editor factory for LayerTreeView. Substitutes default ExternalProperty editor
 //! with custom one, which will offer the choice between all defined materials.
 
-class CustomLayerTreeEditorFactory : public ModelView::DefaultEditorFactory
+class CustomBeamPropertyEditorFactory : public ModelView::DefaultEditorFactory
 {
 public:
-    CustomLayerTreeEditorFactory(ApplicationModels* models);
-    ~CustomLayerTreeEditorFactory();
+    CustomBeamPropertyEditorFactory(ApplicationModels* models);
+    ~CustomBeamPropertyEditorFactory();
 
     std::unique_ptr<ModelView::CustomEditor> createEditor(const QModelIndex& index) const;
 
@@ -29,4 +29,4 @@ private:
     ApplicationModels* m_models;
 };
 
-#endif // DAREFL_LAYEREDITOR_CUSTOMLAYERTREEEDITORFACTORY_H
+#endif // DAREFL_QUICKSIMEDITOR_CUSTOMBEAMPROPERTYEDITORFACTORY_H

--- a/source/darefl/quicksimeditor/quicksimcontroller.cpp
+++ b/source/darefl/quicksimeditor/quicksimcontroller.cpp
@@ -44,6 +44,8 @@ void QuickSimController::setModels(ApplicationModels* models)
         m_models->materialModel(), on_model_change);
     m_sampleChangedController = std::make_unique<ModelView::ModelHasChangedController>(
         m_models->sampleModel(), on_model_change);
+    m_instrumentChangedController = std::make_unique<ModelView::ModelHasChangedController>(
+        m_models->instrumentModel(), on_model_change);
 
     setup_jobmanager_connections();
 

--- a/source/darefl/quicksimeditor/quicksimcontroller.h
+++ b/source/darefl/quicksimeditor/quicksimcontroller.h
@@ -64,6 +64,7 @@ private:
 
     std::unique_ptr<ModelView::ModelHasChangedController> m_materialChangedController;
     std::unique_ptr<ModelView::ModelHasChangedController> m_sampleChangedController;
+    std::unique_ptr<ModelView::ModelHasChangedController> m_instrumentChangedController;
 };
 
 #endif // DAREFL_QUICKSIMEDITOR_QUICKSIMCONTROLLER_H

--- a/source/darefl/quicksimeditor/quicksimoptionswidget.cpp
+++ b/source/darefl/quicksimeditor/quicksimoptionswidget.cpp
@@ -12,8 +12,12 @@
 #include <darefl/model/applicationmodels.h>
 #include <darefl/model/instrumentitems.h>
 #include <darefl/model/instrumentmodel.h>
+#include <darefl/quicksimeditor/custombeampropertyeditorfactory.h>
 #include <darefl/quicksimeditor/quicksimoptionswidget.h>
+#include <mvvm/viewmodel/viewmodeldelegate.h>
 #include <mvvm/widgets/propertytreeview.h>
+
+using namespace ModelView;
 
 QuickSimOptionsWidget::QuickSimOptionsWidget(QWidget* parent)
     : QWidget(parent), m_beamPropertyEditor(new ModelView::PropertyTreeView)
@@ -28,6 +32,11 @@ QuickSimOptionsWidget::~QuickSimOptionsWidget() = default;
 void QuickSimOptionsWidget::setModels(ApplicationModels* models)
 {
     auto instrument = models->instrumentModel()->topItem<SpecularInstrumentItem>();
+
+    auto delegate = std::make_unique<ViewModelDelegate>();
+    delegate->setEditorFactory(std::make_unique<CustomBeamPropertyEditorFactory>(models));
+    m_beamPropertyEditor->setViewModelDelegate(std::move(delegate));
+
     m_beamPropertyEditor->setItem(
         instrument->item<SpecularBeamItem>(SpecularInstrumentItem::P_BEAM));
 }

--- a/tests/testdareflcore/instrumentitems.test.cpp
+++ b/tests/testdareflcore/instrumentitems.test.cpp
@@ -1,0 +1,59 @@
+// ************************************************************************** //
+//
+//  Reflectometry simulation software prototype
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include <darefl/model/experimentaldataitems.h>
+#include <darefl/model/instrumentmodel.h>
+#include <darefl/model/instrumentitems.h>
+#include <mvvm/model/sessionmodel.h>
+#include <mvvm/standarditems/axisitems.h>
+#include <mvvm/standarditems/data1ditem.h>
+#include <mvvm/standarditems/graphitem.h>
+
+using namespace ModelView;
+
+//! Tests of ExperimentalDataModel.
+
+class InstrumentItemsTest : public ::testing::Test
+{
+public:
+    ~InstrumentItemsTest();
+};
+
+InstrumentItemsTest::~InstrumentItemsTest() = default;
+
+TEST_F(InstrumentItemsTest, experimentalScanItemInitialState)
+{
+    ExperimentalScanItem item;
+    EXPECT_EQ(item.graphItem(), nullptr);
+    EXPECT_TRUE(item.qScanValues().empty());
+}
+
+TEST_F(InstrumentItemsTest, experimentalScanGetValues)
+{
+    InstrumentModel model;
+
+    // preparing DataItem
+    auto data_item = model.insertItem<Data1DItem>();
+    std::vector<double> expected_content = {1.0, 2.0, 3.0};
+    std::vector<double> expected_centers = {0.5, 1.5, 2.5};
+    data_item->setAxis(FixedBinAxisItem::create(3, 0.0, 3.0));
+    data_item->setContent(expected_content);
+
+    // preparing GraphItem
+    auto graph_item = model.insertItem<GraphItem>();
+    graph_item->setDataItem(data_item);
+
+    // preparing ScanItem
+    auto scan_item = model.insertItem<ExperimentalScanItem>();
+    scan_item->setGraphItem(graph_item);
+
+    EXPECT_EQ(scan_item->graphItem(), graph_item);
+    EXPECT_EQ(scan_item->qScanValues(), expected_centers);
+}


### PR DESCRIPTION
It is possible now to run simulations using either Q-scan (with parameters, adjustable from corresponding property editor), or using the x-axis of imported data. Any change in this setting triggers quick simulations.

The special controller listens ExperimentalDataModel and makes sure, that InstrumentModel is up-to-dated.

